### PR TITLE
出力内容のテンプレート化a

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,246 @@
+# 上位ディレクトリから .editorconfig 設定を継承する場合は、以下の行を削除します
+root = true
+
+# C# ファイル
+[*.cs]
+
+#### コア EditorConfig オプション ####
+
+# インデントと間隔
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# 改行設定
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET コード アクション ####
+
+# 型メンバー
+dotnet_hide_advanced_members = false
+dotnet_member_insertion_location = with_other_members_of_the_same_kind
+dotnet_property_generation_behavior = prefer_throwing_properties
+
+# シンボルの検索
+dotnet_search_reference_assemblies = true
+
+#### .NET コーディング規則 ####
+
+# using の整理
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. と Me. の設定
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# 言語キーワードと BCL の種類の設定
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# かっこの設定
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# 修飾子設定
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# 式レベルの設定
+dotnet_prefer_system_hash_code = true
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_collection_expression = when_types_loosely_match
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# フィールド設定
+dotnet_style_readonly_field = true
+
+# パラメーターの設定
+dotnet_code_quality_unused_parameters = all
+
+# 抑制の設定
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# 改行設定
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# コーディング規則 ####
+
+# var を優先
+csharp_style_var_elsewhere = false
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = false
+
+# 式のようなメンバー
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
+
+# パターン マッチング設定
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null チェック設定
+csharp_style_conditional_delegate_call = true
+
+# 修飾子設定
+csharp_prefer_static_anonymous_function = true
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+csharp_style_prefer_readonly_struct = true
+csharp_style_prefer_readonly_struct_member = true
+
+# コード ブロックの設定
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = true
+csharp_prefer_system_threading_lock = true
+csharp_style_namespace_declarations = block_scoped
+csharp_style_prefer_method_group_conversion = true
+csharp_style_prefer_primary_constructors = true
+csharp_style_prefer_top_level_statements = true
+
+# 式レベルの設定
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_implicitly_typed_lambda_expression = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_unbound_generic_type_in_nameof = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' ディレクティブの基本設定
+csharp_using_directive_placement = outside_namespace
+
+# 改行設定
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# 書式ルール ####
+
+# 改行設定
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# インデント設定
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# スペース設定
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# 折り返しの設定
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### 命名スタイル ####
+
+# 名前付けルール
+
+dotnet_naming_rule.interface_should_be_i_で始まる.severity = suggestion
+dotnet_naming_rule.interface_should_be_i_で始まる.symbols = interface
+dotnet_naming_rule.interface_should_be_i_で始まる.style = i_で始まる
+
+dotnet_naming_rule.型_should_be_パスカル_ケース.severity = suggestion
+dotnet_naming_rule.型_should_be_パスカル_ケース.symbols = 型
+dotnet_naming_rule.型_should_be_パスカル_ケース.style = パスカル_ケース
+
+dotnet_naming_rule.フィールド以外のメンバー_should_be_パスカル_ケース.severity = suggestion
+dotnet_naming_rule.フィールド以外のメンバー_should_be_パスカル_ケース.symbols = フィールド以外のメンバー
+dotnet_naming_rule.フィールド以外のメンバー_should_be_パスカル_ケース.style = パスカル_ケース
+
+# 記号の仕様
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.型.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.型.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.型.required_modifiers = 
+
+dotnet_naming_symbols.フィールド以外のメンバー.applicable_kinds = property, event, method
+dotnet_naming_symbols.フィールド以外のメンバー.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.フィールド以外のメンバー.required_modifiers = 
+
+# 命名スタイル
+
+dotnet_naming_style.パスカル_ケース.required_prefix = 
+dotnet_naming_style.パスカル_ケース.required_suffix = 
+dotnet_naming_style.パスカル_ケース.word_separator = 
+dotnet_naming_style.パスカル_ケース.capitalization = pascal_case
+
+dotnet_naming_style.i_で始まる.required_prefix = I
+dotnet_naming_style.i_で始まる.required_suffix = 
+dotnet_naming_style.i_で始まる.word_separator = 
+dotnet_naming_style.i_で始まる.capitalization = pascal_case

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Configuration;
 using System.Data;
 using System.Windows;
+using Application = System.Windows.Application;
 
 namespace Fortnite_Replay_Parser_GUI
 {

--- a/Form.xaml
+++ b/Form.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="Fortnite_Replay_Parser_GUI.Form"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Fortnite_Replay_Parser_GUI"
+        mc:Ignorable="d"
+        Title="Form" Height="450" Width="800">
+    <Grid>
+        
+    </Grid>
+</Window>

--- a/Form.xaml.cs
+++ b/Form.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Fortnite_Replay_Parser_GUI
+{
+    /// <summary>
+    /// Form.xaml の相互作用ロジック
+    /// </summary>
+    public partial class Form : Window
+    {
+        public Form()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Fortnite_Replay_Parser_GUI.csproj
+++ b/Fortnite_Replay_Parser_GUI.csproj
@@ -13,9 +13,12 @@
 	<IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
 	<EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
 	<Configurations>Debug;Release;Publish</Configurations>
+	<UseWindowsForms>True</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FortniteReplayReader" Version="2.4.0" />
+    <PackageReference Include="Scriban" Version="6.3.0" />
+    <PackageReference Include="System.Management" Version="9.0.9" />
   </ItemGroup>
 </Project>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -29,7 +29,7 @@
             Grid.Column="1" 
             SelectionChanged="ComboBox_SelectionChanged" Grid.ColumnSpan="6" Height="22" 
             />
-        <TextBox x:Name="tb_Parseed_Result" HorizontalAlignment="Left" Margin="10,119,0,0" TextWrapping="Wrap" Text="TextBox&#xD;&#xA;" VerticalAlignment="Top" VerticalScrollBarVisibility="Auto" Width="780" Height="300" Grid.Column="1" Grid.ColumnSpan="6" />
+        <TextBox x:Name="tb_Parse_Result" HorizontalAlignment="Left" Margin="10,119,0,0" TextWrapping="Wrap" Text="TextBox&#xD;&#xA;" VerticalAlignment="Top" VerticalScrollBarVisibility="Auto" Width="780" Height="300" Grid.Column="1" Grid.ColumnSpan="6" />
         <TextBox x:Name="TimeAdjustment" Grid.ColumnSpan="2" HorizontalAlignment="Left" HorizontalContentAlignment="Right"  Margin="13,428,0,0" TextWrapping="Wrap" Text="0" VerticalAlignment="Top" Width="120" TextChanged="TimeAdjustment_TextChanged" Height="22" Grid.Column="2"/>
         <Label Content="Time Offset for Video -" Grid.ColumnSpan="3" HorizontalAlignment="Left" Margin="10,426,0,0" VerticalAlignment="Top" Width="142" Height="26"/>
         <Button x:Name="btn_SaveReplayJson" Grid.Column="5" Content="Save Replay Data as JSON..." HorizontalAlignment="Left" Margin="284,429,0,0" VerticalAlignment="Top" RenderTransformOrigin="0.525,0.039" Click="Button_Click_btn_SaveReplayJson" Width="166" Grid.ColumnSpan="2"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace Fortnite_Replay_Parser_GUI
         /// <returns>The full path of the selected replay file, or <see langword="null"/> if the user cancels the dialog.</returns>
         protected string GetReplayFileInteractive()
         {
-            OpenFileDialog ofd = new OpenFileDialog();
+            Microsoft.Win32.OpenFileDialog ofd = new Microsoft.Win32.OpenFileDialog();
             ofd.Filter = "Replay Files (.replay)|*.replay";
             ofd.InitialDirectory = this.fnReplayDirectory;
 
@@ -156,16 +156,19 @@ namespace Fortnite_Replay_Parser_GUI
                 return;
             }
 
+            /*
             if (this.fnSelectedPlayer != null && this.fnSelectedPlayer.getPlayer().PlayerId != null)
             {
                 // 指定されたプレイヤーのマッチデータ取得
-                tb_Parseed_Result.Text = this.fortniteReplayHelper.GetMatchData(fnSelectedPlayer.getPlayer(), this.fnTimingOffset);
+                tb_Parse_Result.Text = this.fortniteReplayHelper.GetMatchData(fnSelectedPlayer.getPlayer(), this.fnTimingOffset);
             }
             else
             {
                 // プレイヤーが選択されていない場合は基本のマッチデータを取得
-                tb_Parseed_Result.Text = this.fortniteReplayHelper.GetMatchData(null, this.fnTimingOffset);
+                tb_Parse_Result.Text = this.fortniteReplayHelper.GetMatchData(null, this.fnTimingOffset);
             }
+            */
+            tb_Parse_Result.Text = this.fortniteReplayHelper.RenderMatchResultFromTemplate(fnSelectedPlayer == null ? null: fnSelectedPlayer.getPlayer(), this.fnTimingOffset);
         }
 
         /// <summary>

--- a/System/Windows/Forms/OpenFileDialog.cs
+++ b/System/Windows/Forms/OpenFileDialog.cs
@@ -1,9 +1,0 @@
-﻿namespace System.Windows.Forms
-{
-    internal class OpenFileDialog
-    {
-        public OpenFileDialog()
-        {
-        }
-    }
-}

--- a/Templates/MatchResult.cs
+++ b/Templates/MatchResult.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fortnite_Replay_Parser_GUI.Templates
+{
+    internal class MatchResult
+    {
+        public static string MatchStatTemplate = """
+            ======== Match Stats =========
+            Started : {{ started_at }}
+            Ended : {{ ended_at }}
+            Duration : {{ duration }}
+            Total Players: {{ total_players }}(Humans : {{ human_players }} / Bots : {{ bot_players }})
+            {{ player_result }}
+            {{ system_info }}
+            =============================
+            (This output has been provided by: https://github.com/Kumapapa2012/Fortnite_Replay_Parser_GUI/)
+            """;
+
+        public static string PlayerResultTemplate = """
+            =================
+            Player: {{ player_name }}
+            =================
+            {{ for elim in eliminations }}
+            {{ fn_form_number elim.index }}: {{ elim.time }} - {{ elim.player_name }}({{ if elim.is_bot }}bot{{ else }}human{{ end }}){{ end }}
+            {{ if eliminated }}
+            {{ player_name }} was eliminated by {{ eliminated.player_name }}({{ if eliminated.is_bot }}bot{{ else }}human{{ end }}) at {{ eliminated.time }}
+            {{ else }}
+            ==== {{ player_name }} got a Victory Royale!! ====
+            {{ end }}
+            =================            
+            """;
+    }
+}

--- a/Templates/SystemInfoHelper.cs
+++ b/Templates/SystemInfoHelper.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+using System.Management;
+using System.Drawing; // 参照追加必要
+using System.Windows.Forms; // 参照追加必要
+using Microsoft.Win32;
+
+namespace Fortnite_Replay_Parser_GUI.Templates
+{
+    public static class SystemInfoHelper
+    {
+        public static string GetGPU()
+        {
+            try
+            {
+                using var searcher = new ManagementObjectSearcher("select * from Win32_VideoController");
+                foreach (var obj in searcher.Get())
+                {
+                    var name = obj["Name"]?.ToString();
+                    if (!string.IsNullOrEmpty(name))
+                        return name;
+                }
+            }
+            catch { }
+            return "Unknown GPU";
+        }
+
+        public static string GetCPU()
+        {
+            try
+            {
+                using var searcher = new ManagementObjectSearcher("select * from Win32_Processor");
+                foreach (var obj in searcher.Get())
+                {
+                    var name = obj["Name"]?.ToString();
+                    if (!string.IsNullOrEmpty(name))
+                        return name;
+                }
+            }
+            catch { }
+            return "Unknown CPU";
+        }
+
+        public static string GetMemory()
+        {
+            try
+            {
+                using var searcher = new ManagementObjectSearcher("select * from Win32_ComputerSystem");
+                foreach (var obj in searcher.Get())
+                {
+                    var total = Convert.ToDouble(obj["TotalPhysicalMemory"]) / (1024 * 1024 * 1024);
+                    return $"{Math.Round(total, 2)} GB RAM";
+                }
+            }
+            catch { }
+            return "Unknown Memory";
+        }
+
+        public static string GetAvailableMemory()
+        {
+            try
+            {
+                using var searcher = new ManagementObjectSearcher("select * from Win32_OperatingSystem");
+                foreach (var obj in searcher.Get())
+                {
+                    var available = Convert.ToDouble(obj["FreePhysicalMemory"]) / (1024 * 1024);
+                    return $"{Math.Round(available, 2)} GB RAM は使用可能です";
+                }
+            }
+            catch { }
+            return "";
+        }
+
+        public static string GetResolution()
+        {
+            try
+            {
+                var primaryScreen = System.Windows.Forms.Screen.PrimaryScreen;
+                if (primaryScreen == null)
+                    return "Unknown Resolution";
+                // RefreshRate プロパティは存在しないため、解像度のみ返す
+                return $"{primaryScreen.Bounds.Width} x {primaryScreen.Bounds.Height}";
+            }
+            catch { }
+            return "Unknown Resolution";
+        }
+
+        public static string GetOS()
+        {
+            try
+            {
+                string[] OsDescription = System.Runtime.InteropServices.RuntimeInformation.OSDescription.Split(".");
+                if (OsDescription.Length >= 2 && OsDescription[0].Contains("Windows 10"))
+                {
+                    // Windows 10, Windows 11 の場合、メジャーバージョンとマイナーバージョンを使用して OS 名を特定
+                    if ( int.TryParse(OsDescription[2], out int value))
+                    {
+                        if(value >= 22000) {
+                            return "Windows 11";
+                        }
+                        else {
+                            return "Windows 10 or earlier";
+                        }
+                    }
+                    else
+                    {
+                        // OS情報を返す
+                        return "Windows 10 or earlier";
+                    }
+                }
+            }
+            catch { }
+            return "Unknown OS";
+        }
+
+        public static string GetSystemInfoText()
+        {
+            return
+                $"GPU：{GetGPU()}\n" +
+                $"CPU：{GetCPU()}\n" +
+                $"メモリ：{GetMemory()} ({GetAvailableMemory()})\n" +
+                $"現在の解像度：{GetResolution()}\n" +
+                $"オペレーティング システム： {GetOS()}";
+        }
+    }
+}


### PR DESCRIPTION
出力内容のテンプレート化a

C# コーディング規則の追加と UI の改善

.editorconfig に C# コーディング規則やスタイル設定を追加しました。App.xaml.cs に Application のエイリアスを追加し、アプリケーションのエントリポイントを明確化しました。Form.xaml と Form.xaml.cs にウィンドウの定義とロジックを追加し、UI を構築しました。

FortniteReplayHelper.cs ではリプレイデータの読み込みやプレイヤー情報取得のメソッドを追加し、コメントを日本語に翻訳しました。また、RenderMatchResultFromTemplate と RenderPlayerResultFromTemplate メソッドを追加し、Scriban テンプレートを使用してマッチ結果をレンダリングする機能を実装しました。

プロジェクトファイルに Scriban と System.Management のパッケージ参照を追加し、新機能を利用可能にしました。MainWindow.xaml で TextBox の名前を変更し、UI の一貫性を向上させました。MainWindow.xaml.cs ではファイルダイアログのクラスを修正し、明確な名前空間を使用しました。

MatchResult.cs にマッチ結果を表示するためのテンプレートを追加し、プレイヤーの戦績表示機能を強化しました。SystemInfoHelper.cs にはシステム情報を取得するメソッドを追加し、GPU、CPU、メモリ、解像度、OS 情報を取得する機能を実装しました。