### PR TITLE
時間オフセット適用ボタンを追加

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -75,13 +75,26 @@
                HorizontalAlignment="Left" VerticalAlignment="Bottom"
                Margin="0,0,0,5" Height="26" Grid.RowSpan="2"/>
 
+
+        <!-- 下部固定領域: TimeAdjustment ボタン （左寄せ、Bottom固定） -->
+        <Button x:Name="btn_ApplyOffset" 
+                Grid.Column="1" 
+                Content="Apply" 
+                HorizontalAlignment="Left" 
+                Margin="249,0,0,0" 
+                Grid.Row="5" 
+                VerticalAlignment="Center" 
+                IsEnabled="False" 
+Click="Button_Click_btn_ApplyOffset"/>
+
+
         <!-- 下部固定領域: TimeAdjustment（左寄せ、Bottom固定） -->
         <TextBox x:Name="TimeAdjustment" 
                  Grid.Row="5" Grid.Column="1"
                  HorizontalAlignment="Left" VerticalAlignment="Top"
                  Margin="124,5,0,5" Width="120" Height="22"
                  HorizontalContentAlignment="Right"
-                 Text="0" TextChanged="TimeAdjustment_TextChanged"/>
+                 Text="0" TextChanged="TimeAdjustment_TextChanged" KeyDown="TimeAdjustment_KeyDown"/>
 
         <!-- 下部固定領域: Save ボタン（右寄せ・Bottom固定、右オフセットは列の右余白で確保） -->
         <Button x:Name="btn_SaveReplayJson" 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
-﻿using System.Windows;
+﻿using Microsoft.Win32;
+using System.Windows;
 using System.Windows.Controls;
-using Microsoft.Win32;
+using System.Windows.Input;
 
 namespace Fortnite_Replay_Parser_GUI
 {
@@ -11,6 +12,7 @@ namespace Fortnite_Replay_Parser_GUI
     /// </summary>
     public partial class MainWindow : Window
     {
+        private const bool V = true;
         String fnReplayDirectory = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\FortniteGame\\Saved\\Demos";
         String fnReplayFilePath;
 
@@ -172,13 +174,15 @@ namespace Fortnite_Replay_Parser_GUI
         {
             if (Int32.TryParse(TimeAdjustment.Text, out int offset))
             {
-                this.fnTimingOffset = offset;
-                e.Handled = true;
-                UpdateMatchResult();
-            }
-            else
-            {
-                e.Handled = false;
+                if (offset != this.fnTimingOffset)
+                {
+                    btn_ApplyOffset.IsEnabled = true;
+                    e.Handled = true;
+                }
+                else {
+                    btn_ApplyOffset.IsEnabled = false;
+                    e.Handled = false;
+                }
             }
         }
 
@@ -186,6 +190,32 @@ namespace Fortnite_Replay_Parser_GUI
         {
             var replayJSONFilePath = GetJSONFileSaveInteractive("replay.json", "JSON Files (*.json)|*.json");
             this.fortniteReplayHelper.SaveReplayAsJSON(replayJSONFilePath);
+        }
+
+        private void ApplyReplayOffset(System.Windows.Controls.TextBox TimeAdjustment)
+        {
+            if (Int32.TryParse(TimeAdjustment.Text, out int offset))
+            {
+                this.fnTimingOffset = offset;
+                UpdateMatchResult();
+                btn_ApplyOffset.IsEnabled = false;
+            }
+        }
+
+        private void Button_Click_btn_ApplyOffset(object sender, RoutedEventArgs e)
+        {
+            ApplyReplayOffset(TimeAdjustment);
+            e.Handled = true;
+        }
+
+        private void TimeAdjustment_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                // Apply the offset when Enter key is pressed
+                ApplyReplayOffset(TimeAdjustment);
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
時間オフセット適用ボタンを追加

MainWindow.xaml にビデオの時間オフセットを適用するためのボタン（`btn_ApplyOffset`）を追加しました。`TextBox` の `KeyDown` イベントを処理し、オフセットが変更された際にボタンが有効化されるようにしました。

MainWindow.xaml.cs では、`using` ステートメントを追加し、`fnTimingOffset` を更新するための `ApplyReplayOffset` メソッドを新たに実装しました。ボタンがクリックされたときや `Enter` キーが押されたときにオフセットが適用されるようになっています。