### PR TITLE
Add copy to clipboard functionality for parse results

### DIFF
--- a/wwwroot/css/style.css
+++ b/wwwroot/css/style.css
@@ -95,6 +95,14 @@ select:disabled {
     margin: 8px 0;
     min-height: 200px;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.result-header {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 4px;
 }
 
 #parseResult {

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -30,6 +30,9 @@
 
         <!-- 結果表示 -->
         <div class="result-area">
+            <div class="result-header">
+                <button id="btnCopyResult" disabled>Copy to Clipboard</button>
+            </div>
             <pre id="parseResult"></pre>
         </div>
 

--- a/wwwroot/js/app.js
+++ b/wwwroot/js/app.js
@@ -6,11 +6,44 @@ const parseResult = document.getElementById("parseResult");
 const timeAdjustment = document.getElementById("timeAdjustment");
 const btnApplyOffset = document.getElementById("btnApplyOffset");
 const btnSaveJson = document.getElementById("btnSaveJson");
+const btnCopyResult = document.getElementById("btnCopyResult");
 const loading = document.getElementById("loading");
 
 // --- 状態 ---
 let currentSessionId = null;
 let currentOffset = 0;
+
+// --- コピーボタンの状態更新 ---
+function updateCopyButton() {
+    btnCopyResult.disabled = !parseResult.textContent;
+}
+
+// --- コピーボタン ---
+btnCopyResult.addEventListener("click", async () => {
+    try {
+        await navigator.clipboard.writeText(parseResult.textContent);
+        const original = btnCopyResult.textContent;
+        btnCopyResult.textContent = "Copied!";
+        setTimeout(() => {
+            btnCopyResult.textContent = original;
+        }, 2000);
+    } catch {
+        // clipboard API が使えない場合のフォールバック
+        const textarea = document.createElement("textarea");
+        textarea.value = parseResult.textContent;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+        const original = btnCopyResult.textContent;
+        btnCopyResult.textContent = "Copied!";
+        setTimeout(() => {
+            btnCopyResult.textContent = original;
+        }, 2000);
+    }
+});
 
 // --- ローディング表示 ---
 function showLoading() {
@@ -33,6 +66,7 @@ replayFileInput.addEventListener("change", async (e) => {
     playerSelect.innerHTML = '<option value="-1">-- 読み込み中... --</option>';
     playerSelect.disabled = true;
     parseResult.textContent = "";
+    updateCopyButton();
     btnSaveJson.hidden = true;
     btnApplyOffset.disabled = true;
     timeAdjustment.value = "0";
@@ -71,6 +105,7 @@ replayFileInput.addEventListener("change", async (e) => {
         await fetchResult(-1, 0);
     } catch (err) {
         parseResult.textContent = "エラー: " + err.message;
+        updateCopyButton();
     } finally {
         hideLoading();
     }
@@ -112,8 +147,10 @@ async function fetchResult(playerIndex, offset) {
 
         const data = await resp.json();
         parseResult.textContent = data.result;
+        updateCopyButton();
     } catch (err) {
         parseResult.textContent = "エラー: " + err.message;
+        updateCopyButton();
     }
 }
 


### PR DESCRIPTION
## Summary
Added a "Copy to Clipboard" button that allows users to easily copy the parsed replay results to their clipboard with visual feedback.

## Key Changes
- **New UI Component**: Added a "Copy to Clipboard" button in the result area header with proper styling and layout
- **Copy Functionality**: Implemented clipboard copying with:
  - Primary support using the modern Clipboard API (`navigator.clipboard.writeText`)
  - Fallback implementation using `document.execCommand("copy")` for older browsers
  - Visual feedback that changes button text to "Copied!" for 2 seconds after successful copy
- **Button State Management**: 
  - Button is disabled when no parse results are available
  - `updateCopyButton()` function manages button state based on result content
  - State is updated whenever parse results change (success, error, or file load)
- **Layout Updates**: Modified result area to use flexbox layout to accommodate the new button header

## Implementation Details
- The copy button is positioned in a new `.result-header` div above the parse results
- Button state is synchronized with result content across all code paths (initial load, fetch success, fetch error)
- Graceful degradation ensures clipboard functionality works across different browser environments

https://claude.ai/code/session_01JLg9171VpyqKt8SmbVMp8B